### PR TITLE
Refactor board Pt2

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,10 @@ task default: %w[lint test]
 task :test do
   ruby 'test/game_match_test.rb'
   ruby 'test/board_block_test.rb'
+  ruby 'test/board_actions_test.rb'
+  ruby 'test/board_creation_test.rb'
+  ruby 'test/mark_diagonal_cells_test.rb'
+  ruby 'test/mark_nesw_cells_test.rb'
 end
 
 RuboCop::RakeTask.new(:lint) do |task|

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -3,6 +3,7 @@
 require_relative 'board_block'
 # Board initialized board and applies moves to blocks
 class Board
+  TEST_BOMBS = [[0, 0], [1, 1], [2, 2], [2, 3]].freeze
   attr_accessor :win_condition, :played_blocks
   attr_reader :n_rows, :n_cols, :board, :bomb_spawn_rate
 
@@ -23,6 +24,19 @@ class Board
       end
     end
     @win_condition = (n_rows * n_cols) - total_bombs
+  end
+
+  def controlled_populate_blocks
+    @win_condition = (n_rows * n_cols) - TEST_BOMBS.length
+    @n_rows.times do |row|
+      @n_cols.times do |col|
+        @board["(#{row}, #{col})"] = if TEST_BOMBS.include? [row, col]
+                                       BoardBlock.new(self, true)
+                                     else
+                                       BoardBlock.new(self, false)
+                                     end
+      end
+    end
   end
 
   def block_and_bomb_spawn(row, col)

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -96,7 +96,7 @@ class Board
   def apply_action_to_block(action, row, col)
     actual = @board["(#{row}, #{col})"]
     if action == 'flag'
-      actual.flagged = !actual.flagged
+      actual.flagged = !actual.flagged unless actual.played
     else
       return false if actual.bomb
 

--- a/test/board_actions_test.rb
+++ b/test/board_actions_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+require_relative '../lib/board'
+require 'test/unit'
+
+# Class to Test actions in board-blocks
+class ExampleTest < Test::Unit::TestCase
+  def setup
+    @board = Board.new(8, 8, 0.5)
+    @board.controlled_populate_blocks
+    @board.mark_contiguous
+  end
+
+  def test_do_blocks_counting_bombs
+    @board.do_blocks_counting
+    assert_equal(@board.board['(0, 1)'].n_contiguous_bombs, 2)
+  end
+
+  def test_do_blocks_counting_zero_blocks
+    # duda de como contar los zero blocks
+    @board.do_blocks_counting
+    assert_equal(@board.board['(0, 1)'].contiguous_zero_blocks.length, 4)
+  end
+end

--- a/test/board_actions_test.rb
+++ b/test/board_actions_test.rb
@@ -22,4 +22,35 @@ class ExampleTest < Test::Unit::TestCase
     @board.do_blocks_counting
     assert_equal(@board.board['(0, 1)'].contiguous_zero_blocks.length, 4)
   end
+
+  def test_play_action_empty_position
+    @board.do_blocks_counting
+    @board.apply_action_to_block('play', 0, 1)
+    assert_equal(@board.board['(0, 1)'].played, true)
+  end
+ 
+  def test_play_action_flagged_position
+    @board.do_blocks_counting
+    @board.apply_action_to_block('flag', 0, 1)
+    @board.apply_action_to_block('play', 0, 1)
+    assert_equal(@board.board['(0, 1)'].played, false)
+  end
+ 
+  def test_play_action_bomb_position
+    @board.do_blocks_counting
+    assert_equal(@board.apply_action_to_block('play', 0, 0), false)
+  end
+ 
+  def test_flag_action_empty_position
+    @board.do_blocks_counting
+    @board.apply_action_to_block('flag', 0, 1)
+    assert_equal(@board.board['(0, 1)'].flagged, true)
+  end
+ 
+  def test_flag_action_played_position
+    @board.do_blocks_counting
+    @board.apply_action_to_block('play', 0, 1)
+    @board.apply_action_to_block('flag', 0, 1)
+    assert_equal(@board.board['(0, 1)'].flagged, false)
+  end
 end


### PR DESCRIPTION
+ Agregué los test restantes de Board, que consistieron en test de los métodos `apply_action_to_block` y `do_blocks_counting`.
+ Agregue un método que puebla controladamente las bombas de un tablero para los tests del punto anterior.
+ Arregle el error generado por poner una bandera en una posición que ya se había jugado.
